### PR TITLE
MPT-22665 Skip PR Teams notification for Dependabot

### DIFF
--- a/.github/workflows/pr-build-merge.yaml
+++ b/.github/workflows/pr-build-merge.yaml
@@ -125,7 +125,7 @@ jobs:
         run: uv run pytest
 
       - name: Compute added/removed lines for notification
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
         id: diff
         run: |
           PR_DATA=$(gh pr view "${{ github.event.pull_request.number }}" --json additions,deletions -q '.')
@@ -137,7 +137,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Notify Microsoft Teams
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
         uses: softwareone-platform/notify-pr-teams-action@v4
         with:
           webhook_url: ${{ secrets.TEAMS_WEBHOOK_URL }}


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What
Guard the two PR-notification steps in the `build` job (`pr-build-merge.yaml`) with `&& github.actor != 'dependabot[bot]'`:
- "Compute added/removed lines for notification"
- "Notify Microsoft Teams"

## Why
On Dependabot PRs `secrets.TEAMS_WEBHOOK_URL` is empty (Dependabot has no access to repository secrets), so the notify action receives an empty webhook URL and `curl` fails with `URL rejected: Malformed input to a URL function` — failing the whole `build` job even though tests pass. This currently blocks every Dependabot PR (#68–#74). Real PRs are unaffected and still post the notification.

## Testing
Workflow YAML validated; diff is limited to the two `if:` conditions.
